### PR TITLE
Don't run CodeQL workflow on a schedule.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: 0 0 * * 0
 
 jobs:
   analyse:


### PR DESCRIPTION
Now we're updating with Dependabot there's not really a point to this.