### PR TITLE
Add support for concise map syntax.

### DIFF
--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -78,7 +78,9 @@ func ReadWorkflow(name string, rawWorkflow []byte) (*Workflow, error) {
 			if err != nil {
 				return nil, errors.Wrap(err, "Unable to parse workflow as typed YAML.")
 			}
-			if typedParsedWorkflow.On.WorkflowDispatch != nil {
+			if workflowDispatchTrigger, ok := typedOn[workflowDispatch]; ok && workflowDispatchTrigger == nil {
+				workflow.Dispatchable = true
+			} else if typedParsedWorkflow.On.WorkflowDispatch != nil {
 				workflow.Dispatchable = true
 				if typedParsedWorkflow.On.WorkflowDispatch.Inputs != nil {
 					for _, inputData := range *typedParsedWorkflow.On.WorkflowDispatch.Inputs {

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -55,6 +55,18 @@ on:
 	require.Empty(t, workflowData.Inputs)
 }
 
+func TestReadDispatchableWorkflowConciseMapStyle(t *testing.T) {
+	const workflowContent = `
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+`
+	workflowData := parseTestWorkflow(t, workflowContent)
+	require.True(t, workflowData.Dispatchable)
+	require.Empty(t, workflowData.Inputs)
+}
+
 func TestReadWorkflowWithInputs(t *testing.T) {
 	const workflowContent = `
 on:


### PR DESCRIPTION
Currently workflows that look like

```yaml
on:
  workflow_dispatch:
```

are not considered dispatchable. This is actually a bug, as the `workflow_dispatch` key being present is sufficient for the workflow to be dispatchable; it doesn't matter that it is null.
