### PR TITLE
Suppress extra logging from the retrying client.

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"io"
+	"log"
+
 	"github.com/cli/go-gh"
 	"github.com/cli/go-gh/pkg/api"
 	"github.com/hashicorp/go-retryablehttp"
@@ -10,6 +13,7 @@ import (
 func NewClient(host string) (api.RESTClient, error) {
 	retryableHTTPClient := retryablehttp.NewClient()
 	retryableHTTPClient.RetryMax = 5
+	retryableHTTPClient.Logger = log.New(io.Discard, "", log.LstdFlags)
 	retryableRoundTripper := retryablehttp.RoundTripper{Client: retryableHTTPClient}
 
 	client, err := gh.RESTClient(&api.ClientOptions{Host: host, Transport: &retryableRoundTripper})


### PR DESCRIPTION
Sadly the client does not work well with Logrus so prints some pretty spammy debug information. To work around this, we can just throw away log output.