### PR TITLE
Handle more input default types.

### DIFF
--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -132,9 +132,7 @@ func ReadWorkflow(name string, rawWorkflow []byte) (*Workflow, error) {
 							}
 						}
 						if inputDefault, ok := mapInputConfiguration["default"]; ok {
-							if input.Default, ok = inputDefault.(string); !ok {
-								return nil, errors.Errorf("Input default for %s had unexpected type %T.", input.Name, inputDefault)
-							}
+							input.Default = fmt.Sprintf("%v", inputDefault)
 						}
 						workflow.Inputs = append(workflow.Inputs, input)
 					}


### PR DESCRIPTION
The Actions documentation is not super consistent about what types the default field can have, but a variety seem to work.